### PR TITLE
Tesla fleet integration

### DIFF
--- a/apps/TeslaPublicKey.yaml
+++ b/apps/TeslaPublicKey.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tesla-public-key
+  namespace: default
+spec:
+  interval: 1h
+  path: ./apps/generic/overlays/tesla-public-key/
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: k8s-infrastructure
+    namespace: kube-system
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: tesla-public-key
+      namespace: default
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: secrets

--- a/apps/generic/overlays/tesla-public-key/configmap.yaml
+++ b/apps/generic/overlays/tesla-public-key/configmap.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tesla-public-key
+data:
+  # Non-secret EC P-256 public key. Must match the private key at
+  # HA's config/tesla_fleet.key (generated together via openssl).
+  com.tesla.3p.public-key.pem: |
+    -----BEGIN PUBLIC KEY-----
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEh5ur3PRFsJ16HmHd8IWU92GbyUbZ
+    QrQu2OShB+CkScC7cH+12mL9YHVP9PR3IeyMW1RJJufigVgL33bzMpvwqQ==
+    -----END PUBLIC KEY-----

--- a/apps/generic/overlays/tesla-public-key/kustomization.yaml
+++ b/apps/generic/overlays/tesla-public-key/kustomization.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ../../base/
+  - configmap.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: tesla-public-key
+    includeSelectors: true
+
+patches:
+  - path: patches/deployment.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: deployment
+      namespace: default
+    options:
+      allowNameChange: true
+  - path: patches/ingress.yaml
+    target:
+      group: networking.k8s.io
+      version: v1
+      kind: Ingress
+      name: ingress
+      namespace: default
+    options:
+      allowNameChange: true
+  - path: patches/service.yaml
+    target:
+      group: ""
+      version: v1
+      kind: Service
+      name: service
+      namespace: default
+    options:
+      allowNameChange: true
+  # The generic base attaches yasr/backup/main PVCs; this static server only
+  # needs the public-key ConfigMap, so replace the volumes list entirely.
+  - patch: |-
+      - op: replace
+        path: /spec/template/spec/volumes
+        value:
+          - name: pubkey
+            configMap:
+              name: tesla-public-key
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: tesla-public-key
+  - patch: |-
+      - op: replace
+        path: /spec/rules/0/host
+        value: tesla.${CLUSTER_DOMAIN_NAME}
+      - op: replace
+        path: /spec/rules/0/http/paths/0/path
+        value: /.well-known/appspecific/com.tesla.3p.public-key.pem
+      - op: replace
+        path: /spec/rules/0/http/paths/0/pathType
+        value: Exact
+      - op: replace
+        path: /spec/rules/0/http/paths/0/backend/service/name
+        value: tesla-public-key
+      - op: replace
+        path: /spec/tls/0/hosts/0
+        value: tesla.${CLUSTER_DOMAIN_NAME}
+    target:
+      group: networking.k8s.io
+      version: v1
+      kind: Ingress
+      name: tesla-public-key

--- a/apps/generic/overlays/tesla-public-key/kustomization.yaml
+++ b/apps/generic/overlays/tesla-public-key/kustomization.yaml
@@ -62,7 +62,7 @@ patches:
         value: /.well-known/appspecific/com.tesla.3p.public-key.pem
       - op: replace
         path: /spec/rules/0/http/paths/0/pathType
-        value: Exact
+        value: ImplementationSpecific
       - op: replace
         path: /spec/rules/0/http/paths/0/backend/service/name
         value: tesla-public-key

--- a/apps/generic/overlays/tesla-public-key/patches/deployment.yaml
+++ b/apps/generic/overlays/tesla-public-key/patches/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tesla-public-key
+spec:
+  template:
+    spec:
+      containers:
+        - name: container
+          image: nginx:alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          volumeMounts:
+            - name: pubkey
+              mountPath: /usr/share/nginx/html/.well-known/appspecific/com.tesla.3p.public-key.pem
+              subPath: com.tesla.3p.public-key.pem
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /.well-known/appspecific/com.tesla.3p.public-key.pem
+              port: http
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /.well-known/appspecific/com.tesla.3p.public-key.pem
+              port: http
+            initialDelaySeconds: 5
+            timeoutSeconds: 10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi

--- a/apps/generic/overlays/tesla-public-key/patches/ingress.yaml
+++ b/apps/generic/overlays/tesla-public-key/patches/ingress.yaml
@@ -1,0 +1,4 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tesla-public-key

--- a/apps/generic/overlays/tesla-public-key/patches/service.yaml
+++ b/apps/generic/overlays/tesla-public-key/patches/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tesla-public-key
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http

--- a/clusters/rafag/apps/kustomization.yaml
+++ b/clusters/rafag/apps/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../../apps/Bitwarden.yaml
   - ../../../apps/Forecastle.yaml
   - ../../../apps/HomeAssistant.yaml
+  - ../../../apps/TeslaPublicKey.yaml
   - ../../../apps/MosquitoMQTTBroker.yaml
   - ../../../apps/Paperless.yaml
   - ../../../apps/Photoprism.yaml


### PR DESCRIPTION
In order to control the Tesla via home assistant, you need a service that can publish a public key to communicate with the fleet. 